### PR TITLE
(sighs in JavaScript)

### DIFF
--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -470,8 +470,13 @@ class AwsProvider {
   }
 
   getDeploymentPrefix() {
-    const prefix = this.serverless.service.provider.deploymentPrefix;
-    return !prefix && prefix !== '' ? 'serverless' : prefix;
+    const provider = this.serverless.service.provider;
+    if (!('deploymentPrefix' in provider)) {
+      return 'serverless;
+    }
+
+    const prefix = provider.deploymentPrefix;
+    return (prefix || '') + '';
   }
 
   getLogRetentionInDays() {

--- a/lib/plugins/aws/provider/awsProvider.js
+++ b/lib/plugins/aws/provider/awsProvider.js
@@ -470,7 +470,8 @@ class AwsProvider {
   }
 
   getDeploymentPrefix() {
-    return this.serverless.service.provider.deploymentPrefix || 'serverless';
+    const prefix = this.serverless.service.provider.deploymentPrefix;
+    return !prefix && prefix !== '' ? 'serverless' : prefix;
   }
 
   getLogRetentionInDays() {


### PR DESCRIPTION
This allows setting `deploymentPrefix: ''` in `serverless.yml` to use an empty `deploymentPrefix` instead of the default "serverless" prefix. Without this change, `deploymentPrefix: ''`, `deploymentPrefix: 0`, `deploymentPrefix: off`, `deploymentPrefix: false`, etc. all are equivalent to `deploymentPrefix: serverless`.

Note that this will only clear out the `deploymentPrefix` if one is explicitly included in the config file, or if the deploymentPrefix is falsey (e.g. `false`). If the key is not included, it will still return "serverless".

This could be interpreted as a breaking change, although I can imagine that the number of folks impacted is very small.